### PR TITLE
Fix Runner import list

### DIFF
--- a/src/Runner.py
+++ b/src/Runner.py
@@ -1,4 +1,4 @@
-from src.ErrorCode import RegistryReadError, ExecutionError
+from src.ErrorCode import RegistryReadError, ExecutionError, RegexMatchError
 
 import subprocess
 import winreg


### PR DESCRIPTION
## Summary
- include `RegexMatchError` in `src.Runner` imports